### PR TITLE
[bazel] Fix compatibility_level

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@
 # *******************************************************************************
 module(
     name = "bazel_tools_python",
-    version = "0.1.0",
+    version = "0.1.1",
     compatibility_level = 0,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 module(
     name = "bazel_tools_python",
     version = "0.1.0",
-    compatibility_level = 1,
+    compatibility_level = 0,
 )
 
 # Checker rule for CopyRight checks/fixs


### PR DESCRIPTION
While migrating the repository and resetting the module version, the bazel compatibility_level was false left at 1, which is not in line with a version of 0.1.0. Hence, the compatibility_level is set to 0.