### PR TITLE
Align module name with name in registry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,9 +11,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 module(
-    name = "bazel_tools_python",
+    name = "score_bazel_tools_python",
     version = "0.1.1",
     compatibility_level = 0,
+    repo_name = "bazel_tools_python",
 )
 
 # Checker rule for CopyRight checks/fixs

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add this to your `MODULE.bazel` file.
 ```python
 # MODULE.bazel
 
-bazel_dep(name = "bazel_tools_python", version = "<version>")
+bazel_dep(name = "score_bazel_tools_python", version = "<version>", repo_name = "bazel_tools_python")
 ```
 
 To generate Bazel integrity value, one can use the following command:


### PR DESCRIPTION
# Bugfix

## Description

When trying to use the module with `bazel_dep` you will get the following error:

    ERROR: in module dependency chain <root> -> score_bazel_tools_python@0.1.1: the MODULE.bazel file of score_bazel_tools_python@0.1.1 declares a different name (bazel_tools_python)

## Related ticket

closes #4

