### PR TITLE
[pipaudit] Add option to ignore vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,8 +57,7 @@ The following table lists all known vulnerabilities that could not be fixed:
 | ---------- | ------------------- | ------------------ | ------------- | -------------- | ------------------------------------ |
 | urllib3    | GHSA-48p4-8xcf-vxj5 | 2.2.3              | 2.5.0         | 3.8            | Fixed package requires Python >= 3.9 |
 | urllib3    | GHSA-pq67-6m6q-mj2v | 2.2.3              | 2.5.0         | 3.8            | Fixed package requires Python >= 3.9 |
-| pip        | GHSA-4xh5-x5gv-qwph | 25.0.1             | 25.2          | 3.8            | Fixed package requires Python >= 3.9 |
-| pip        | GHSA-4xh5-x5gv-qwph | 25.2               | -             | All            | Waiting for an open source fix       |
+| pip        | GHSA-4xh5-x5gv-qwph | 25.0.1             | 25.3          | 3.8            | Fixed package requires Python >= 3.9 |
 
 ### Vulnerable Python Versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,8 @@ The following table lists all known vulnerabilities that could not be fixed:
 | ---------- | ------------------- | ------------------ | ------------- | -------------- | ------------------------------------ |
 | urllib3    | GHSA-48p4-8xcf-vxj5 | 2.2.3              | 2.5.0         | 3.8            | Fixed package requires Python >= 3.9 |
 | urllib3    | GHSA-pq67-6m6q-mj2v | 2.2.3              | 2.5.0         | 3.8            | Fixed package requires Python >= 3.9 |
+| pip        | GHSA-4xh5-x5gv-qwph | 25.0.1             | 25.2          | 3.8            | Fixed package requires Python >= 3.9 |
+| pip        | GHSA-4xh5-x5gv-qwph | 25.2               | -             | All            | Waiting for an open source fix       |
 
 ### Vulnerable Python Versions
 

--- a/quality/private/python/python_pip_audit_rule.bzl
+++ b/quality/private/python/python_pip_audit_rule.bzl
@@ -28,6 +28,9 @@ def _pip_audit_rule_impl(ctx):
     requirement_file = ctx.file.requirement
 
     args_list = ["--disable-pip"]
+    if ctx.attr.ignore_vulnerability:
+        for vulnerability in ctx.attr.ignore_vulnerability:
+            args_list.extend(["--ignore-vuln", vulnerability])
     if ctx.attr.no_deps:
         args_list.append("--no-deps")
     if ctx.attr.index_url:
@@ -55,6 +58,13 @@ def _pip_audit_rule_impl(ctx):
 pip_audit_rule = rule(
     implementation = _pip_audit_rule_impl,
     attrs = {
+        "ignore_vulnerability": attr.string_list(
+            default = [],
+            doc = (
+                "Optional. If set, pip-audit will ignore a specific set of vulnerabilities by their IDs." +
+                "If not provided, all vulnerabilities will be checked."
+            ),
+        ),
         "index_url": attr.string(
             default = "",
             doc = (

--- a/third_party/pip/BUILD
+++ b/third_party/pip/BUILD
@@ -50,12 +50,6 @@ EXTRA_ARGS = [
 [
     pip_audit_rule(
         name = "pip_audit_requirements_{}".format(version.replace(".", "_")),
-        # The list of ignored vulnerabilities should ideally be empty, but sometimes a certain vulnerability
-        # does not have a fix yet. In that case, we ignore it with `--ignore-vul` to avoid CI failures.
-        # Keep this in sync with SECURITY.md.
-        ignore_vulnerability = [
-            "GHSA-4xh5-x5gv-qwph",  # Added because there is no fix yet for pip 25.2.
-        ],
         requirement = "requirements_lock_{}.txt".format(version.replace(".", "_")),
     )
     for version in PYTHON_VERSIONS

--- a/third_party/pip/BUILD
+++ b/third_party/pip/BUILD
@@ -50,6 +50,12 @@ EXTRA_ARGS = [
 [
     pip_audit_rule(
         name = "pip_audit_requirements_{}".format(version.replace(".", "_")),
+        # The list of ignored vulnerabilities should ideally be empty, but sometimes a certain vulnerability
+        # does not have a fix yet. In that case, we ignore it with `--ignore-vul` to avoid CI failures.
+        # Keep this in sync with SECURITY.md.
+        ignore_vulnerability = [
+            "GHSA-4xh5-x5gv-qwph",  # Added because there is no fix yet for pip 25.2.
+        ],
         requirement = "requirements_lock_{}.txt".format(version.replace(".", "_")),
     )
     for version in PYTHON_VERSIONS

--- a/third_party/pip/requirements_lock_3_10.txt
+++ b/third_party/pip/requirements_lock_3_10.txt
@@ -827,7 +827,7 @@ webencodings==0.5.1 \
     # via html5lib
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2 \
-    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
-    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
     # via pip-api

--- a/third_party/pip/requirements_lock_3_11.txt
+++ b/third_party/pip/requirements_lock_3_11.txt
@@ -782,7 +782,7 @@ webencodings==0.5.1 \
     # via html5lib
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2 \
-    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
-    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
     # via pip-api

--- a/third_party/pip/requirements_lock_3_12.txt
+++ b/third_party/pip/requirements_lock_3_12.txt
@@ -782,7 +782,7 @@ webencodings==0.5.1 \
     # via html5lib
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2 \
-    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
-    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
     # via pip-api

--- a/third_party/pip/requirements_lock_3_9.txt
+++ b/third_party/pip/requirements_lock_3_9.txt
@@ -828,7 +828,7 @@ webencodings==0.5.1 \
     # via html5lib
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2 \
-    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
-    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
+pip==25.3 \
+    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
+    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
     # via pip-api


### PR DESCRIPTION
Extend the pipaudit rule, adding an option to ignore vulnerabilities.

Sometimes a vulnerability does not have a fix yet. In such a case, the user must be able to ignore those as there is no other option for third-party libraries.

One such case is the vulnerability `https://github.com/advisories/GHSA-4xh5-x5gv-qwph`, which is now affecting pip 25.2 as well but there is still no fix for it. Hence, it needs to be tolerated.