### PR TITLE
[bazel] Align rules_python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It's important to note that this repository does not supply python toolchains bu
 Additionaly, one must have the following bazel repositories already in place:
 
 - bazel_skylib >= 1.7.1
-- rules_python >= 0.40.0
+- rules_python >= 1.4.1
 
 ### Select python pip hub version
 

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -47,29 +47,15 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")  # 
 ]
 
 load("@rules_python//python:pip.bzl", "pip_parse")
-load("@test_python_3_10//:defs.bzl", python_3_10_interpreter = "interpreter")  # buildifier: disable=out-of-order-load
-load("@test_python_3_11//:defs.bzl", python_3_11_interpreter = "interpreter")  # buildifier: disable=out-of-order-load
-load("@test_python_3_12//:defs.bzl", python_3_12_interpreter = "interpreter")  # buildifier: disable=out-of-order-load
-load("@test_python_3_8//:defs.bzl", python_3_8_interpreter = "interpreter")  # buildifier: disable=out-of-order-load
-load("@test_python_3_9//:defs.bzl", python_3_9_interpreter = "interpreter")  # buildifier: disable=out-of-order-load
-
-# buildifier: disable=unsorted-dict-items
-python_interpreter_versions = {
-    "3.8": python_3_8_interpreter,
-    "3.9": python_3_9_interpreter,
-    "3.10": python_3_10_interpreter,
-    "3.11": python_3_11_interpreter,
-    "3.12": python_3_12_interpreter,
-}
 
 [
     pip_parse(
         name = "test_pip_{}".format(version.replace(".", "_")),
         extra_pip_args = ["--no-cache-dir"],
-        python_interpreter_target = python_interpreter_versions[version],
+        python_interpreter_target = "@test_python_{}_host//:python".format(version.replace(".", "_")),
         requirements_lock = "@bazel_tools_python_test//pip:requirements_lock_{}.txt".format(version.replace(".", "_")),
     )
-    for version in python_interpreter_versions
+    for version in PYTHON_VERSIONS
 ]
 
 load("@test_pip_3_10//:requirements.bzl", pip_install_deps_py_3_10 = "install_deps")  # buildifier: disable=out-of-order-load

--- a/third_party/python_pip_parse.bzl
+++ b/third_party/python_pip_parse.bzl
@@ -13,31 +13,16 @@
 
 """Parse pip requirements files for supported python version."""
 
-load("@bazel_tools_python_python_3_10//:defs.bzl", python_3_10_interpreter = "interpreter")
-load("@bazel_tools_python_python_3_11//:defs.bzl", python_3_11_interpreter = "interpreter")
-load("@bazel_tools_python_python_3_12//:defs.bzl", python_3_12_interpreter = "interpreter")
-load("@bazel_tools_python_python_3_8//:defs.bzl", python_3_8_interpreter = "interpreter")
-load("@bazel_tools_python_python_3_9//:defs.bzl", python_3_9_interpreter = "interpreter")
+load("@bazel_tools_python//bazel/toolchains/python:versions.bzl", "PYTHON_VERSIONS")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 def python_pip_parse():
     """Parse pip requirements files for supported python version."""
 
-    # We can't dynamically load the interpreters so the following dict versions need to match
-    # "@bazel_tools_python//bazel/toolchains/python:versions.bzl%PYTHON_VERSIONS"
-    # buildifier: disable=unsorted-dict-items
-    python_versions = {
-        "3.8": python_3_8_interpreter,
-        "3.9": python_3_9_interpreter,
-        "3.10": python_3_10_interpreter,
-        "3.11": python_3_11_interpreter,
-        "3.12": python_3_12_interpreter,
-    }
-
-    for version in python_versions:
+    for version in PYTHON_VERSIONS:
         pip_parse(
             name = "bazel_tools_python_pip_{}".format(version.replace(".", "_")),
             requirements_lock = "@bazel_tools_python//third_party/pip:requirements_lock_{}.txt".format(version.replace(".", "_")),
-            python_interpreter_target = python_versions[version],
+            python_interpreter_target = "@bazel_tools_python_python_{}_host//:python".format(version.replace(".", "_")),
             extra_pip_args = ["--no-cache-dir"],
         )

--- a/third_party/rules_python/rules_python.bzl
+++ b/third_party/rules_python/rules_python.bzl
@@ -15,13 +15,13 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-_VERSION = "0.40.0"  # Update `README.md` if you change this.
+_VERSION = "1.4.1"  # Update `README.md` if you change this.
 
 def rules_python():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "690e0141724abb568267e003c7b6d9a54925df40c275a870a4d934161dc9dd53",
+        sha256 = "9f9f3b300a9264e4c77999312ce663be5dee9a56e361a1f6fe7ec60e1beef9a3",
         strip_prefix = "rules_python-{version}".format(version = _VERSION),
         urls = ["https://github.com/bazel-contrib/rules_python/releases/download/{version}/rules_python-{version}.tar.gz".format(version = _VERSION)],
         patches = ["@bazel_tools_python//third_party/rules_python:rules_python.patch"],


### PR DESCRIPTION
Align the rules_python python versions between workspace and bzlmod mode, in particular update the version for workspace mode to 1.4.1.

With the update a breaking change on how the python interpreter is referenced got introduced in rules_python and required changes.