### PR TITLE
Discontinue repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# DISCLAIMER
+
+> This repository is not longer actively maintained due to the unwillingness of the eclipse governing body to grant the maintainers with the permissions needed to approve and merge pull requests of one another.
+> As a consequence security vulnerabilities in the repository and its dependencies will not be fixed.
+
 # Bazel Rules Quality Python (bazel_tools_python)
 
 This repository contains bazel integrations for python quality tools.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -75,9 +75,6 @@ if [ "${workspace}" == "all" -o "${workspace}" == "main" ];then
 	# Run Eclipse-specific checks.
 	run_command "bazel run //:copyright.check -- --fix" "eclipse copyright check"
 	run_command "bazel test //:format.check" "eclipse format check"
-
-	# Run security vulnerability scan.
-	run_command "third_party/pip/check_vulnerabilities.sh" "security scan"
 fi
 
 if [ "${workspace}" == "all" -o "${workspace}" == "test" ];then


### PR DESCRIPTION
Add a disclaimer to the main readme file to indicate that the repository is no longer actively maintained. As a consequence disable the pip-audit security vulnerability checker to allow contributors to still merge pull requests without being blocked by pip-audit.